### PR TITLE
#165714549 adds failing test for user profile api endpoint

### DIFF
--- a/server/__test__/users.test.js
+++ b/server/__test__/users.test.js
@@ -1,0 +1,63 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import jwt from 'jsonwebtoken';
+import app from '../../app';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+let userToken, wrongIdToken;
+
+describe('/USER PROFILE', () => {
+
+	before('generate JWT', (done) => {
+		userToken = jwt.sign({
+			email: 'josephnjuguna482@gmail.com',
+			id: 2,
+			firstname: 'Joseph',
+			lastname: 'Njuguna',
+			address: 'Kenya',
+		},
+		process.env.JWT_KEY, {
+			expiresIn: '1h',
+		});
+		wrongIdToken = jwt.sign({
+			email: 'josephnjuguna482@gmail.com',
+			id: 1087,
+			firstname: 'Joseph',
+			lastname: 'Njuguna',
+			address: 'Kenya',
+		},
+		process.env.JWT_KEY, {
+			expiresIn: '1h',
+		});
+		done();
+	});
+
+	describe('/GET user profile data using tokens', () => {
+
+		it('should check user ID,EMAIL is not available', (done) => {
+			chai.request(app)
+				.get('/api/v1/profile')
+				.set('authorization', `Bearer ${wrongIdToken}`)
+				.end((err, res) => {
+                    expect(res.body.status).equal(404);
+					if (err) return done();
+					done();
+				});
+		});
+
+		it('should check user ID,EMAIL is available and return user data', (done) => {
+			chai.request(app)
+				.get('/api/v1/profile')
+				.set('authorization', `Bearer ${userToken}`)
+				.end((err, res) => {
+                    expect(res.body.status).equal(200);
+					if (err) return done();
+					done();
+				});
+        });
+        
+    });
+
+});


### PR DESCRIPTION
### What does this PR do?
- [ ] add failing test for user profile api endpoint
### Description of the task to be completed?
- [ ] test user profile api endpoint
### How should this be manually tested?

- [ ] clone this repo to your machine  using :
 ` https://github.com/JosephNjuguna/QuickCreditV1.git`

- [ ] navigate to the QuickCredit folder where you cloned the repo and open QuickCredit directory in terminal 

- [ ]  To run test on user profile api endpoint, use command **`npm test`** .

### Any background context you want to provide?
- [ ] testing user profile api endpoint
- [ ] for a user to get their saved info they must be logged in and use their token to access their information.

### Relevant pivotal tracker stories ?
- [ ] https://www.pivotaltracker.com/story/show/165714549
