### PR TITLE
#165714841 test admin get all loan applications api endpoint

### DIFF
--- a/server/__test__/loan.test.js
+++ b/server/__test__/loan.test.js
@@ -4,10 +4,21 @@ import chaiHttp from 'chai-http';
 import app from '../../app';
 
 chai.use(chaiHttp);
-let userToken;
+let userToken, adminToken;
 
 describe('/LOAN', () => {
     before('generate JWT', (done) => {
+        adminToken = jwt.sign({
+                email: 'admin123@gmail.com',
+                id: 1,
+                firstname: 'main',
+                lastname: 'admin',
+                address: 'database',
+            },
+            process.env.JWT_KEY, {
+                expiresIn: '1h',
+            });
+
         userToken = jwt.sign({
                 email: 'joenjuguna482@gmail.com',
                 id: 2,
@@ -90,4 +101,30 @@ describe('/LOAN', () => {
         });
 
     });
+
+    describe('/GET admin', () => {
+
+        it('should that user is not admin', (done) => {
+            chai.request(app)
+                .get('/api/v1/loans')
+                .set('authorization', `Bearer ${userToken}`)
+                .end((err, res) => {
+                    res.should.have.status(400);
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should get all loan applications', (done) => {
+            chai.request(app)
+                .get('/api/v1/loans')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    if (err) return done();
+                    done();
+                });
+        });
+
+    })
 });


### PR DESCRIPTION
### What does this PR do?
- [ ] add failing test for admin view all loans api endpoint route
### Description of the task to be completed?
- [ ] test admin view all loans api endpoint route
### How should this be manually tested?
- [ ] clone this repo to your machine  using :
 ` https://github.com/JosephNjuguna/QuickCreditV1.git`
- [ ] navigate to the QuickCredit folder where you cloned the repo and open QuickCredit directory in terminal 
- [ ]  To run the tests on user profile api endpoint, use command **`npm test`** .

**the test should fail**
### Any background context you want to provide?
- [ ] api endpoint should only be accessed by the admin only
### Relevant pivotal tracker stories?

- [ ] https://www.pivotaltracker.com/story/show/165714841
