### PR TITLE
#165714842 test admin can get a specific loan application

### DIFF
--- a/server/__test__/loan.test.js
+++ b/server/__test__/loan.test.js
@@ -3,6 +3,9 @@ import jwt from 'jsonwebtoken';
 import chaiHttp from 'chai-http';
 import app from '../../app';
 
+const {
+    expect
+} = chai;
 chai.use(chaiHttp);
 let userToken, adminToken;
 
@@ -118,6 +121,28 @@ describe('/LOAN', () => {
         it('should get all loan applications', (done) => {
             chai.request(app)
                 .get('/api/v1/loans')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should check a loan id is not available', (done) => {
+            chai.request(app)
+                .get('/api/v1/loan/30000')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    expect(res.body.message).equals("Id not found");
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should get a single loan application', (done) => {
+            chai.request(app)
+                .get('/api/v1/loan/1')
                 .set('authorization', `Bearer ${adminToken}`)
                 .end((err, res) => {
                     res.should.have.status(200);


### PR DESCRIPTION
### What does this PR do?
- [ ] add failing test for admin get a specific loan application api endpoint route.
### Description of the task to be completed?
- [ ] test admin view specific loan application detail api endpoint 
### How should this be manually tested?
- [ ] clone this repo to your machine  using :
 ` https://github.com/JosephNjuguna/QuickCreditV1.git`
- [ ] navigate to the QuickCredit folder where you cloned the repo and open QuickCredit directory in terminal 
- [ ]  To run the tests on user profile api endpoint, use command **`npm test`** .
### Any background context you want to provide?
- [ ] api endpoint should only be accessed by the admin only
### Relevant pivotal tracker stories?
- [ ] https://www.pivotaltracker.com/story/show/165714842

