### PR TITLE
#165714843  test  admin accept loan api endpoint

### DIFF
--- a/server/__test__/loan.test.js
+++ b/server/__test__/loan.test.js
@@ -152,4 +152,42 @@ describe('/LOAN', () => {
         });
 
     })
+    describe('/PATCH loan', () =>{
+
+        it('should check token is provided', (done) => {
+			chai.request(app)
+				.patch('/api/v1/loan/3')
+				.set('authorization', ``)
+				.send({ status: 'accepted' })
+				.end((err, res) => {
+                    expect(res.status).equals(400)
+					if (err) return done();
+					done();
+				});
+        });
+
+        it('should check a loan id is available', (done) => {
+			chai.request(app)
+				.patch('/api/v1/loan/122')
+				.set('authorization', `Bearer ${adminToken}`)
+				.send({ status: 'accepted' })
+				.end((err, res) => {
+                    expect(res.body.message).equals("Loan Id not found")
+					if (err) return done();
+					done();
+				});
+        });
+        
+        it('should update a loan application as accepted', (done) => {
+			chai.request(app)
+				.patch('/api/v1/loan/3')
+				.set('authorization', `Bearer ${adminToken}`)
+				.send({ status: 'accepted' })
+				.end((err, res) => {
+					res.should.have.status(200);
+					if (err) return done();
+					done();
+				});
+		});
+    })
 });


### PR DESCRIPTION
### What does this PR do?

- [ ] add failing test for admin accept loan api endpoint.

### Description of the task to be completed?

- [ ] test admin accept loan api endpoint.

### How should this be manually tested?
- [ ] clone this repo to your machine  using :
 ` https://github.com/JosephNjuguna/QuickCreditV1.git`

- [ ] navigate to the QuickCredit folder where you cloned the repo and open QuickCredit directory in terminal 

- [ ]  To run the tests on user profile api endpoint, use command **`npm test`** .
**test should fail**
### Any background context you want to provide?

- [ ] api endpoint should only be accessed by the admin only

### Relevant pivotal tracker stories?
- [ ] https://www.pivotaltracker.com/story/show/165714843