### PR TITLE
#165715017 test admin get all repaid and non repaid loan api endpoint

### DIFF
--- a/server/__test__/loan.test.js
+++ b/server/__test__/loan.test.js
@@ -151,43 +151,110 @@ describe('/LOAN', () => {
                 });
         });
 
-    })
-    describe('/PATCH loan', () =>{
+    });
+
+    describe('/PATCH loan', () => {
 
         it('should check token is provided', (done) => {
-			chai.request(app)
-				.patch('/api/v1/loan/3')
-				.set('authorization', ``)
-				.send({ status: 'accepted' })
-				.end((err, res) => {
+            chai.request(app)
+                .patch('/api/v1/loan/3')
+                .set('authorization', ``)
+                .send({
+                    status: 'accepted'
+                })
+                .end((err, res) => {
                     expect(res.status).equals(400)
-					if (err) return done();
-					done();
-				});
+                    if (err) return done();
+                    done();
+                });
         });
 
         it('should check a loan id is available', (done) => {
-			chai.request(app)
-				.patch('/api/v1/loan/122')
-				.set('authorization', `Bearer ${adminToken}`)
-				.send({ status: 'accepted' })
-				.end((err, res) => {
+            chai.request(app)
+                .patch('/api/v1/loan/122')
+                .set('authorization', `Bearer ${adminToken}`)
+                .send({
+                    status: 'accepted'
+                })
+                .end((err, res) => {
                     expect(res.body.message).equals("Loan Id not found")
-					if (err) return done();
-					done();
-				});
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should update a loan application as accepted', (done) => {
+            chai.request(app)
+                .patch('/api/v1/loan/3')
+                .set('authorization', `Bearer ${adminToken}`)
+                .send({
+                    status: 'accepted'
+                })
+                .end((err, res) => {
+                    res.should.have.status(200);
+                    if (err) return done();
+                    done();
+                });
+        });
+    });
+
+    describe('/GET  fully paid && not fully paid loan', () => {
+
+        it('should check token is provided', (done) => {
+            chai.request(app)
+                .get('/api/v1/loan?status=accepted&repaid=true')
+                .set('authorization', ``)
+                .end((err, res) => {
+                    expect(res.status).equals(400)
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should check if no records of non-fully repaid loan are available', (done) => {
+            chai.request(app)
+                .get('/api/v1/loans?status=accepted&repaid=true')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    expect(res.body.message).equals("no records found")
+                    if (err) return done();
+                    done();
+                });
         });
         
-        it('should update a loan application as accepted', (done) => {
-			chai.request(app)
-				.patch('/api/v1/loan/3')
-				.set('authorization', `Bearer ${adminToken}`)
-				.send({ status: 'accepted' })
-				.end((err, res) => {
-					res.should.have.status(200);
-					if (err) return done();
-					done();
-				});
-		});
-    })
+        it('should check if records of fully repaid loan are not available', (done) => {
+            chai.request(app)
+                .get('/api/v1/loans?status=accepted&repaid=rue')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    expect(res.body.message).equals("no records found")
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should get all loans fully paid', (done) => {
+            chai.request(app)
+                .get('/api/v1/loan?status=accepted&repaid=true')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    expect(res.status).equals(200);
+                    if (err) return done();
+                    done();
+                });
+        });
+
+        it('should get all loans NOT fully paid', (done) => {
+            chai.request(app)
+                .get('/api/v1/loan?status=accepted&repaid=false')
+                .set('authorization', `Bearer ${adminToken}`)
+                .end((err, res) => {
+                    expect(res.status).equals(200);
+                    if (err) return done();
+                    done();
+                });
+        });
+
+    });
+
 });


### PR DESCRIPTION
### What does this PR do?

- [ ] add failing test for admin get all current repaid and non -repaid loan api endpoint

- [ ] this should test a function that can get all current loans not fully paid/ fully paid loans

### Description of the task to be completed?

- [ ] test admin api endpoint where he/she can get all loans fully paid/ loan not fully paid

### How should this be manually tested?

- [ ] clone this repo to your machine  using :
 ` https://github.com/JosephNjuguna/QuickCreditV1.git`

- [ ] navigate to the QuickCredit folder where you cloned the repo and open QuickCredit directory in terminal 

- [ ]  To run the tests on user profile api endpoint, use command **`npm test`** .

**test should fail**

### Any background context you want to provide?

- [ ] this api endpoint will and should only be accessed by the admin.

### Relevant pivotal tracker stories?

- [ ] https://www.pivotaltracker.com/story/show/165715017