### PR TITLE
#165711996 Ft admin get current loans : pending/fully paid/not fully paid

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm run prod

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "nodemon server.js --exec babel-node --",
     "test": "nyc mocha --require babel-register ./server/__test__/*.js  --timeout 150000 --exit",
     "coverage": "npm test && nyc report --reporter=text-lcov | coveralls",
-    "lint": "node_modules/.bin/eslint ./ --fix"
+    "lint": "node_modules/.bin/eslint ./ --fix",
+    "prod": "babel-node server.js"
   },
   "repository": {
     "type": "git",

--- a/server/__test__/loan.test.js
+++ b/server/__test__/loan.test.js
@@ -211,28 +211,6 @@ describe('/LOAN', () => {
                 });
         });
 
-        it('should check if no records of non-fully repaid loan are available', (done) => {
-            chai.request(app)
-                .get('/api/v1/loans?status=accepted&repaid=true')
-                .set('authorization', `Bearer ${adminToken}`)
-                .end((err, res) => {
-                    expect(res.body.message).equals("no records found")
-                    if (err) return done();
-                    done();
-                });
-        });
-        
-        it('should check if records of fully repaid loan are not available', (done) => {
-            chai.request(app)
-                .get('/api/v1/loans?status=accepted&repaid=rue')
-                .set('authorization', `Bearer ${adminToken}`)
-                .end((err, res) => {
-                    expect(res.body.message).equals("no records found")
-                    if (err) return done();
-                    done();
-                });
-        });
-
         it('should get all loans fully paid', (done) => {
             chai.request(app)
                 .get('/api/v1/loan?status=accepted&repaid=true')

--- a/server/controllers/Loans.js
+++ b/server/controllers/Loans.js
@@ -92,6 +92,28 @@ class Loans {
 		});
 	}
 
+	static async loanRepaidstatus(req, res) {
+		const {
+			status,
+			repaid,
+		} = req.query;
+		
+		const loanstatus = new Models({
+			status,
+			repaid
+		});
+		if (!await loanstatus.loanRepaidstatus()) {
+			return res.status(404).json({
+				status: 404,
+				message: 'no records found',
+			});
+		}
+		return res.status(200).json({
+			status: 200,
+			message: 'loan status',
+			data: loanstatus.result,
+		});
+	}
 }
 
 export default Loans;

--- a/server/models/Loans.js
+++ b/server/models/Loans.js
@@ -128,6 +128,26 @@ class LoanModel {
 		return true;
 	}
 
+	async loanRepaidstatus() {
+
+		const { status,repaid } = this.payload;
+		
+		let repaidStatus;
+
+		if(repaid === 'false'){
+			repaidStatus = false;
+		}else if(repaid === 'true'){
+			repaidStatus = true;
+		}
+
+		const obj = db.filter(o => o.status === status && o.repaid === repaidStatus);		
+		if (obj.length === 0) {
+			return false;
+		}
+		this.result = obj;
+		return true;
+	}
+
 	
 }
 export default LoanModel;

--- a/server/routes/loans.js
+++ b/server/routes/loans.js
@@ -23,4 +23,8 @@ route.patch('/loan/:loan_id',
 	checkAuth.checkAdmin,
 	loans.acceptloanapplication);
 
+route.get('/loan',
+	checkAuth.checkAdmin,
+	loans.loanRepaidstatus);
+
 export default route;


### PR DESCRIPTION

### What does this PR do?
- [ ] adds api endpoint to check loans based on their status

- [ ] updates test file

- [ ] adds heroku configuration

### Description of the task to be completed?

- [ ] enable admin view all current loans based on their status

### How should this be manually tested?

- [ ] clone this repo to your machine  using :
 ` https://github.com/JosephNjuguna/QuickCreditV1.git`

- [ ] navigate to the QuickCredit folder where you cloned the repo and open QuickCredit directory in terminal 

- [ ]  To run test on api endpoints, use command **`npm test`** .

- [ ]  to test in postman, use command **`npm start`**. open postman  and use the following urls to test different loan statuses:

1. ensure you are logged in as admin
2. ensure you use token on your headers : `**Bearer Token: log in token `

**all pending  loans use: **
`http://localhost:3000/api/v1/loan?status=pending&repaid=false`
parameters used:
```
status: pending
repaid:false
```

**all fully paid loans use: **
`http://localhost:3000/api/v1/loan?status=accepted&repaid=true`
parameters used:
```
status:accepted
repaid: true
```

** loans, not fully paid use: **
`http://localhost:3000/api/v1/loan?status=accepted&repaid=false`
parameters used:
```
status: accepted
repaid: false
```
### Any background context you want to provide?

- [ ] this PR ensures test passes

### Relevant pivotal tracker stories ?
- [ ] https://www.pivotaltracker.com/story/show/165711996